### PR TITLE
[WIP] Quest attached to Books

### DIFF
--- a/assets/prefabs/BookQuest.prefab
+++ b/assets/prefabs/BookQuest.prefab
@@ -1,0 +1,55 @@
+ {
+    "parent" : "engine:iconItem",
+    "Item" : {
+        "icon" : "engine:items#brownBook",
+        "usage" : "ON_USER"
+    },
+    "DisplayName" : {
+        "name" : "Book"
+    },
+    "Book" : {
+        "tint" : [245, 222, 179, 255]
+    },
+    "InteractionTarget": {},
+    "InteractionScreen": {
+        "screen": "Books:BookScreen"
+    },
+    "Quest" : {
+        "shortName" : "TestBookQuest",
+        "description" : "Test this quest on book!",
+        "tasks" : [
+            {
+                "id" : "collectDirt",
+                "type" : "CollectBlocksTask",
+                "dependsOn" : ["collectDirtInTime"],
+                "data" : {
+                    "itemId" : "block:core:Dirt",
+                    "amount" : 5
+                }
+            },
+            {
+                "id" : "collectDirtInTime",
+                "type" : "TimeConstraintTask",
+                "data" : {
+                    "targetTime" : 60
+                }
+            },
+            {
+                "id" : "returnHome",
+                "type" : "GoToBeaconTask",
+                "dependsOn" : "collectDirt",
+                "data" : {
+                    "beaconId" : "homeBeacon"
+                }
+            },
+            {
+                "id" : "returnHomeInTime",
+                "dependsOn" : ["collectDirt"],
+                "type" : "TimeConstraintTask",
+                "data" : {
+                    "targetTime" : 30
+                }
+            }
+        ]
+    }
+}

--- a/assets/prefabs/BookQuest.prefab
+++ b/assets/prefabs/BookQuest.prefab
@@ -9,7 +9,9 @@
     },
     "Book" : {
         "title" : "Quest Book",
-        "tint" : [245, 222, 179, 255]
+        "tint" : [245, 222, 179, 255],
+        "pages" : ["Here's what you have to do\n    Collect 5 dirt blocks in 60 s\n    Return to Home Beacon in 30s\n\nMay the FORCE be with you...",
+        ""]
     },
     "InteractionTarget": {},
     "InteractionScreen": {

--- a/assets/prefabs/BookQuest.prefab
+++ b/assets/prefabs/BookQuest.prefab
@@ -8,6 +8,7 @@
         "name" : "Book"
     },
     "Book" : {
+        "title" : "Quest Book",
         "tint" : [245, 222, 179, 255]
     },
     "InteractionTarget": {},

--- a/module.txt
+++ b/module.txt
@@ -8,6 +8,10 @@
         {
             "id" : "Tasks",
             "minVersion" : "0.2.0-SNAPSHOT"
+        },
+        {
+            "id" : "Books",
+            "version" : "1.0.2-SNAPSHOT"
         }
     ],
     "isServerSideOnly" : false

--- a/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
+++ b/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
@@ -18,16 +18,12 @@ package org.terasology.quests.examples;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.books.logic.BookComponent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.logic.common.ActivateEvent;
 import org.terasology.tasks.Quest;
-import org.terasology.tasks.Task;
-import org.terasology.tasks.components.QuestComponent;
 import org.terasology.tasks.events.BeforeQuestEvent;
 import org.terasology.tasks.systems.QuestSystem;
 import org.terasology.registry.In;
@@ -42,18 +38,6 @@ public class BookQuestSystem extends BaseComponentSystem {
 
     @In
     private QuestSystem questSystem;
-
-    @ReceiveEvent
-    public void updateBookContent(ActivateEvent event, EntityRef entity, QuestComponent quest, BookComponent book) {
-        String content = "Here's what you have to do:\n";
-        for (Task task : quest.tasks) {
-            content += "    " + task.toString() + '\n';
-        }
-        content += "\nMay the FORCE be with you...";
-
-        book.pages.set(0, content);
-        entity.saveComponent(book);
-    }
 
     /**
      * This method prevents addition of quest if quest with same shortName is active.

--- a/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
+++ b/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
@@ -20,30 +20,45 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.input.events.RightMouseDownButtonEvent;
 import org.terasology.logic.common.ActivateEvent;
+import org.terasology.tasks.Quest;
 import org.terasology.tasks.components.QuestComponent;
+import org.terasology.tasks.systems.QuestSystem;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.registry.In;
 import org.terasology.world.generator.plugin.RegisterPlugin;
+
+import java.util.Collection;
 
 
 /**
  * Handles quest attached to book entity.
  */
-@RegisterSystem(value = RegisterMode.AUTHORITY)
-public class BookQuestSystem {
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class BookQuestSystem extends BaseComponentSystem {
 
     @In
-    private AssetManager assetManager;
+    private QuestSystem questSystem;
 
     private static final Logger logger = LoggerFactory.getLogger(BookQuestSystem.class);
 
+    /**
+     * This method prevents addition of quest if quest with same shortName is active.
+     * @param event Event triggered due to interaction with Quest Book
+     * @param quest Quest component that is currently interacted
+     */
     @ReceiveEvent
-    public void onquestActivated(ActivateEvent event, QuestComponent quest) {
-        logger.warn("oquestActivated called");
+    public void onQuestActivated(ActivateEvent event,  QuestComponent quest) {
+        String name = quest.shortName;
+        for (Quest activeQuest : questSystem.getActiveQuests()) {
+            if (name.equals(activeQuest.getShortName())) {
+                event.consume();
+                logger.warn("Duplicate Quest " + name + " cancelled");
+            }
+        }
     }
-
 }

--- a/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
+++ b/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
@@ -19,6 +19,7 @@ package org.terasology.quests.examples;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
@@ -52,12 +53,13 @@ public class BookQuestSystem extends BaseComponentSystem {
      * @param quest Quest component that is currently interacted
      */
     @ReceiveEvent
-    public void onQuestActivated(ActivateEvent event,  QuestComponent quest) {
+    public void onQuestActivated(ActivateEvent event, EntityRef entity, QuestComponent quest) {
         String name = quest.shortName;
         for (Quest activeQuest : questSystem.getActiveQuests()) {
             if (name.equals(activeQuest.getShortName())) {
                 event.consume();
                 logger.warn("Duplicate Quest " + name + " cancelled");
+                break;
             }
         }
     }

--- a/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
+++ b/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
@@ -28,6 +28,7 @@ import org.terasology.logic.common.ActivateEvent;
 import org.terasology.tasks.Quest;
 import org.terasology.tasks.Task;
 import org.terasology.tasks.components.QuestComponent;
+import org.terasology.tasks.events.BeforeQuestEvent;
 import org.terasology.tasks.systems.QuestSystem;
 import org.terasology.registry.In;
 
@@ -42,23 +43,6 @@ public class BookQuestSystem extends BaseComponentSystem {
 
     private static final Logger logger = LoggerFactory.getLogger(BookQuestSystem.class);
 
-    /**
-     * This method prevents addition of quest if quest with same shortName is active.
-     * @param event Event triggered due to interaction with Quest Book
-     * @param quest Quest component that is currently interacted
-     */
-    @ReceiveEvent
-    public void onQuestActivated(ActivateEvent event, EntityRef entity, QuestComponent quest) {
-        String name = quest.shortName;
-        for (Quest activeQuest : questSystem.getActiveQuests()) {
-            if (name.equals(activeQuest.getShortName())) {
-                event.consume();
-                logger.warn("Duplicate Quest " + name + " cancelled");
-                break;
-            }
-        }
-    }
-
     @ReceiveEvent
     public void updateBookContent(ActivateEvent event, EntityRef entity, QuestComponent quest, BookComponent book) {
         String content = "Here's what you have to do:\n";
@@ -67,8 +51,24 @@ public class BookQuestSystem extends BaseComponentSystem {
         }
         content += "\nMay the FORCE be with you...";
 
-        //List<String> pages = new ArrayList<>(Lists.newArrayList(content, ""));
         book.pages.set(0, content);
         entity.saveComponent(book);
+    }
+
+    /**
+     * This method prevents addition of quest if quest with same shortName is active.
+     * @param event Event triggered by QuestSystem due to interaction with Quest Book
+     * @param entity Entity on which quest is attached
+     */
+    @ReceiveEvent
+    public void onQuestActivated(BeforeQuestEvent event, EntityRef entity) {
+        String name = event.getQuestName();
+        for (Quest activeQuest : questSystem.getActiveQuests()) {
+            if (name.equals(activeQuest.getShortName())) {
+                event.consume();
+                logger.warn("Duplicate Quest " + name + " cancelled");
+                break;
+            }
+        }
     }
 }

--- a/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
+++ b/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.quests.examples;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.input.events.RightMouseDownButtonEvent;
+import org.terasology.logic.common.ActivateEvent;
+import org.terasology.tasks.components.QuestComponent;
+import org.terasology.assets.management.AssetManager;
+import org.terasology.registry.In;
+import org.terasology.world.generator.plugin.RegisterPlugin;
+
+
+/**
+ * Handles quest attached to book entity.
+ */
+@RegisterSystem(value = RegisterMode.AUTHORITY)
+public class BookQuestSystem {
+
+    @In
+    private AssetManager assetManager;
+
+    private static final Logger logger = LoggerFactory.getLogger(BookQuestSystem.class);
+
+    @ReceiveEvent
+    public void onquestActivated(ActivateEvent event, QuestComponent quest) {
+        logger.warn("oquestActivated called");
+    }
+
+}

--- a/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
+++ b/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MovingBlocks
+ * Copyright 2019 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,10 +38,10 @@ import org.terasology.registry.In;
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class BookQuestSystem extends BaseComponentSystem {
 
+    private static final Logger logger = LoggerFactory.getLogger(BookQuestSystem.class);
+
     @In
     private QuestSystem questSystem;
-
-    private static final Logger logger = LoggerFactory.getLogger(BookQuestSystem.class);
 
     @ReceiveEvent
     public void updateBookContent(ActivateEvent event, EntityRef entity, QuestComponent quest, BookComponent book) {
@@ -57,7 +57,8 @@ public class BookQuestSystem extends BaseComponentSystem {
 
     /**
      * This method prevents addition of quest if quest with same shortName is active.
-     * @param event Event triggered by QuestSystem due to interaction with Quest Book
+     *
+     * @param event  Event triggered by QuestSystem due to interaction with Quest Book
      * @param entity Entity on which quest is attached
      */
     @ReceiveEvent

--- a/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
+++ b/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
@@ -18,23 +18,18 @@ package org.terasology.quests.examples;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.books.logic.BookComponent;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.input.events.RightMouseDownButtonEvent;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.tasks.Quest;
+import org.terasology.tasks.Task;
 import org.terasology.tasks.components.QuestComponent;
 import org.terasology.tasks.systems.QuestSystem;
-import org.terasology.assets.management.AssetManager;
 import org.terasology.registry.In;
-import org.terasology.world.generator.plugin.RegisterPlugin;
-
-import java.util.Collection;
-
 
 /**
  * Handles quest attached to book entity.
@@ -62,5 +57,18 @@ public class BookQuestSystem extends BaseComponentSystem {
                 break;
             }
         }
+    }
+
+    @ReceiveEvent
+    public void updateBookContent(ActivateEvent event, EntityRef entity, QuestComponent quest, BookComponent book) {
+        String content = "Here's what you have to do:\n";
+        for (Task task : quest.tasks) {
+            content += "    " + task.toString() + '\n';
+        }
+        content += "\nMay the FORCE be with you...";
+
+        //List<String> pages = new ArrayList<>(Lists.newArrayList(content, ""));
+        book.pages.set(0, content);
+        entity.saveComponent(book);
     }
 }

--- a/src/main/java/org/terasology/quests/examples/QuestPointEntityProvider.java
+++ b/src/main/java/org/terasology/quests/examples/QuestPointEntityProvider.java
@@ -32,6 +32,7 @@ import org.terasology.world.generation.EntityProviderPlugin;
 import org.terasology.world.generation.Region;
 import org.terasology.world.generation.facets.SurfaceHeightFacet;
 import org.terasology.world.generator.plugin.RegisterPlugin;
+import org.terasology.books.logic.BookComponent;
 
 import com.google.common.collect.Lists;
 

--- a/src/main/java/org/terasology/quests/examples/QuestPointEntityProvider.java
+++ b/src/main/java/org/terasology/quests/examples/QuestPointEntityProvider.java
@@ -32,7 +32,6 @@ import org.terasology.world.generation.EntityProviderPlugin;
 import org.terasology.world.generation.Region;
 import org.terasology.world.generation.facets.SurfaceHeightFacet;
 import org.terasology.world.generator.plugin.RegisterPlugin;
-import org.terasology.books.logic.BookComponent;
 
 import com.google.common.collect.Lists;
 
@@ -67,7 +66,7 @@ public class QuestPointEntityProvider implements EntityProviderPlugin {
 
             buffer.enqueue(questPoint);
         }
-   }
+    }
 
     private boolean contains(Region region, SurfaceHeightFacet heightFacet, Vector2i pos, float heightOff) {
         if (heightFacet.getWorldRegion().contains(pos)) {


### PR DESCRIPTION
Regarding issue : https://github.com/Terasology/Books/issues/21

The aim of this pr is to enable attachment of quests to books, so that player can pursue quest if the book is in the inventory.

How to test:
1. console command `give QuestExamples:BookQuest`
2. Right click with the book selected in inventory
     Expected Behavior: A quest begins
3. Open the book by clicking the arrow button below book display
     Expected Behavior: Contains quest info
4. Right click again with the book selected
     Expected Behavior: No new quest is added 
                                    Quest added if the previous quest time is over

Outstanding before merge :
- [x] Add a book prefab with quest details
- [x] Update QuestPointEntityProvider.java to handle book with quest 
- [ ] Add logic for handling presence of book in inventory