### PR TITLE
Handle removal of book with quest from inventory

### DIFF
--- a/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
+++ b/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
@@ -23,7 +23,9 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.inventory.events.BeforeItemRemovedFromInventory;
 import org.terasology.tasks.Quest;
+import org.terasology.tasks.components.QuestComponent;
 import org.terasology.tasks.events.BeforeQuestEvent;
 import org.terasology.tasks.systems.QuestSystem;
 import org.terasology.registry.In;
@@ -54,6 +56,22 @@ public class BookQuestSystem extends BaseComponentSystem {
                 logger.warn("Duplicate Quest " + name + " cancelled");
                 break;
             }
+        }
+    }
+
+    @ReceiveEvent
+    public void onBookThrown(BeforeItemRemovedFromInventory event, EntityRef entity) {
+        EntityRef entityThrown = event.getItem();
+        if (entityThrown.hasComponent(QuestComponent.class)) {
+            QuestComponent itemQuest = entityThrown.getComponent(QuestComponent.class);
+            for (Quest quest : questSystem.getActiveQuests()) {
+                if (quest.getShortName().equals(itemQuest.shortName)) {
+                    logger.warn("Entity with QuestComponent thrown, removing quest");
+                    questSystem.removeQuest(quest, true);
+                    break;
+                }
+            }
+
         }
     }
 }

--- a/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
+++ b/src/main/java/org/terasology/quests/examples/BookQuestSystem.java
@@ -66,7 +66,6 @@ public class BookQuestSystem extends BaseComponentSystem {
             QuestComponent itemQuest = entityThrown.getComponent(QuestComponent.class);
             for (Quest quest : questSystem.getActiveQuests()) {
                 if (quest.getShortName().equals(itemQuest.shortName)) {
-                    logger.warn("Entity with QuestComponent thrown, removing quest");
                     questSystem.removeQuest(quest, true);
                     break;
                 }


### PR DESCRIPTION
When book with active quest is removed from inventory, the quest is removed.

How to test:
1. Get a quest book by console command `give QuestExamples:BookQuest`
2. Activate quest by right clicking the book
3. Throw the book using `Q`
Expected behavior: Quest is removed

Closes https://github.com/Terasology/Books/issues/21